### PR TITLE
Properly set utf8 flag on perl scalars for URI and Node object values.

### DIFF
--- a/perl/Makefile.PL
+++ b/perl/Makefile.PL
@@ -103,6 +103,7 @@ WriteMakefile(
     'AUTHOR'    => 'Dave Beckett <dave@dajobe.org>',
     'ABSTRACT'  => "Redland RDF library",
     'VERSION'   => $version,
+    'MIN_PERL_VERSION' => '5.007003',
 
     'DEFINE'    => "-DHAVE_CONFIG_H $redland_cflags",
     'OBJECT'    => "$objects",

--- a/perl/lib/RDF/Redland/Node.pm
+++ b/perl/lib/RDF/Redland/Node.pm
@@ -24,6 +24,7 @@
 package RDF::Redland::Node;
 
 use strict;
+use Encode;
 
 use vars qw($Type_Resource $Type_Property $Type_Literal
 	    $Type_Statement $Type_Blank);
@@ -401,7 +402,7 @@ $RDF::Redland::Node::Type_Literal)
 =cut
 
 sub literal_value ($) {
-  &RDF::Redland::CORE::librdf_node_get_literal_value(shift->{NODE});
+  return decode_utf8(&RDF::Redland::CORE::librdf_node_get_literal_value(shift->{NODE}));
 }
 
 =item literal_value_as_latin1
@@ -457,7 +458,8 @@ Return the RDF::Redland::Node formatted as a string (UTF-8 encoded).
 =cut
 
 sub as_string ($) {
-  &RDF::Redland::CORE::librdf_node_to_string(shift->{NODE});
+  my $v = decode_utf8(&RDF::Redland::CORE::librdf_node_to_string(shift->{NODE}));
+  return $v;
 }
 
 =item equals NODE

--- a/perl/lib/RDF/Redland/URI.pm
+++ b/perl/lib/RDF/Redland/URI.pm
@@ -24,6 +24,7 @@
 package RDF::Redland::URI;
 
 use strict;
+use Encode;
 
 =pod
 
@@ -155,7 +156,7 @@ Return the statement formatted as a string (UTF-8 encoded).
 =cut
 
 sub as_string ($) {
-  &RDF::Redland::CORE::librdf_uri_to_string(shift->{URI});
+  return decode_utf8(&RDF::Redland::CORE::librdf_uri_to_string(shift->{URI}));
 }
 
 =item equals URI


### PR DESCRIPTION
This patch properly sets the utf8 flag on the values returned from $uri->as_string and $node->literal_value calls. This is important for perl to be able to make sense of IRI values and literals with non-ascii characters, and do the right thing when comparing or outputting those values.

The redland perl bindings don't currently have a minimum version requirement. This patch sets a required minimum version of perl of 5.7.3 which is needed for its unicode support. Perl 5.7.3 was released 9 years ago, so I don't believe this shouldn't impose much of a burden on existing users of the perl redland bindings.
