### PR TITLE
php: add librdf_php_free_last_log

### DIFF
--- a/php/redland-decl.i
+++ b/php/redland-decl.i
@@ -8,3 +8,4 @@ static librdf_uri* librdf_php_get_null_uri(void);
 static int librdf_php_last_log_level(void);
 static int librdf_php_last_log_code(void);
 static char* librdf_php_last_log_message(void);
+static void librdf_php_free_last_log(void);

--- a/php/redland-post.i
+++ b/php/redland-post.i
@@ -61,6 +61,16 @@ librdf_php_last_log_message(void)
   return librdf_php_log_message;
 }
 
+void
+librdf_php_free_last_log(void)
+{
+  librdf_php_log_level=0;
+  librdf_php_log_code=0;
+  if(librdf_php_log_message)
+    free(librdf_php_log_message);
+  librdf_php_log_message=NULL;
+}
+
 static int
 librdf_php_logger_handler(void *user_data, librdf_log_message *log_msg)
 {


### PR DESCRIPTION
This is used to clear error/log state when continuing past the last error.
