### PR TITLE
ruby: Fall back to RbConfig::CONFIG's arch if rubyarchhdrdir is not set.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -359,6 +359,7 @@ if test "X$RUBY" != X; then
   RUBY_ARCHDIR=`$RUBY -rrbconfig -e "print RbConfig::CONFIG['archdir']"`
   ruby_install_dir_config=`$RUBY -rrbconfig -e "puts RbConfig::CONFIG['$ruby_install_dir_variable']"`
   ruby_header_dir_config=`$RUBY -rrbconfig -e "puts RbConfig::CONFIG['rubyhdrdir']"`
+  ruby_arch_config=`$RUBY -rrbconfig -e "puts RbConfig::CONFIG['arch']"`
   ruby_arch_header_dir_config=`$RUBY -rrbconfig -e "puts RbConfig::CONFIG['rubyarchhdrdir']"`
   ruby_arch_install_dir_config=`$RUBY -rrbconfig -e "puts RbConfig::CONFIG['$ruby_arch_install_dir_variable']"`
   librubyarg_shared=`$RUBY -rrbconfig -e "puts RbConfig::CONFIG['LIBRUBYARG_SHARED']"`
@@ -384,8 +385,13 @@ if test "X$RUBY" != X; then
 
   AC_MSG_CHECKING(Ruby headers dir)
   if test "X$ruby_header_dir_config" != "Xnil" -a "X$ruby_header_dir_config" != "X"; then
-    RUBY_INCLUDES="$RUBY_INCLUDES -I$ruby_header_dir_config -I$ruby_arch_header_dir_config"
-    AC_MSG_RESULT($RUBY_INCLUDES from RbConfig::CONFIG rubyhdrdir and rubyarchhdrdir)
+    if test -d "$ruby_arch_header_dir_config"; then
+      RUBY_INCLUDES="$RUBY_INCLUDES -I$ruby_header_dir_config -I$ruby_arch_header_dir_config"
+      AC_MSG_RESULT($RUBY_INCLUDES from RbConfig::CONFIG rubyhdrdir and rubyarchhdrdir)
+    elif test -d "$ruby_header_dir_config/$ruby_arch_config"; then
+      RUBY_INCLUDES="$RUBY_INCLUDES -I$ruby_header_dir_config -I$ruby_header_dir_config/$ruby_arch_config"
+      AC_MSG_RESULT($RUBY_INCLUDES from RbConfig::CONFIG rubyhdrdir and arch)
+    fi
   else
     if test -r "$RUBY_ARCHDIR/ruby.h"; then
       RUBY_INCLUDES="$RUBY_INCLUDES -I$RUBY_ARCHDIR"


### PR DESCRIPTION
Follow-up to 6a128750: rubyarchhdrdir is only defined from Ruby 2.0 on,
so the header detection would not work correctly if one is using an
earlier version. Instead, first try rubyarchhdrdir and, if the directory
does not exist, fall back to the previous behavior of using arch.
