### PR TITLE
Fill in RUBY_SO_SUFFIX's value from the right variable.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -419,7 +419,7 @@ if test "X$RUBY" != X; then
 	AC_MSG_ERROR(No such RUBY linking type $ruby_linking)
 	;;
   esac
-  RUBY_SO_SUFFIX=$php_linking
+  RUBY_SO_SUFFIX=$ruby_linking
   AC_MSG_CHECKING(Ruby Linking)
   AC_MSG_RESULT(compile '$RUBY_CFLAGS' link '$RUBY_LDFLAGS' suffix $RUBY_SO_SUFFIX)
 else


### PR DESCRIPTION
Its value should come from $ruby_linking, not $php_linking.
