### PR TITLE
Add php-7.0 support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -161,7 +161,9 @@ if test "X$PHP_CONFIG" != X ; then
   PHP_INCLUDES=`$PHP_CONFIG --includes`
   PHP_EXTENSION_DIR=`$PHP_CONFIG --extension-dir`
 
-  if test $PHP_VERSION '>' 5.0.0; then
+  if test $PHP_VERSION '>' 7; then
+    PHP_SWIG="-php7"
+  elif test $PHP_VERSION '>' 5.0.0; then
     PHP_SWIG="-php5"
   else
     PHP_SWIG="-php4"

--- a/php/redland-post.i
+++ b/php/redland-post.i
@@ -132,8 +132,11 @@ librdf_php_world_init(void)
     exception_ce = zend_exception_get_default();
     INIT_CLASS_ENTRY(ee_ce, "RedlandException", NULL);
     redland_exception_ptr = zend_register_internal_class_ex(&ee_ce, 
-                                                            exception_ce, 
-                                                            NULL TSRMLS_CC);
+                                                            exception_ce
+#if PHP_MAJOR_VERSION < 7
+                                                            ,NULL TSRMLS_CC
+#endif
+                                                            );
 #endif
 
     memset(&librdf_php_locator, '\0', sizeof(raptor_locator));

--- a/php/redland-typemap.i
+++ b/php/redland-typemap.i
@@ -1,17 +1,17 @@
-%typemap(in) librdf_uri* %{
-  if(SWIG_ConvertPtr(*$input, (void **) &$1, SWIGTYPE_p_librdf_uri_s, 0) < 0) {
+%typemap(in) librdf_uri %{
+  if(SWIG_ConvertPtr($input, (void **) &$1, SWIGTYPE_p_librdf_uri_s, 0) < 0) {
     /* Allow NULL from php for librdf_uri* */
-    if ((*$input)->type==IS_NULL)
+    if ($input->type==IS_NULL)
       $1=NULL;
    else
       SWIG_PHP_Error(E_ERROR, "Type error in argument $argnum of $symname. Expected $1_descriptor");
   }
 %}
 
-%typemap(in) librdf_node* %{
-  if(SWIG_ConvertPtr(*$input, (void **) &$1, SWIGTYPE_p_librdf_node_s, 0) < 0) {
+%typemap(in) librdf_node %{
+  if(SWIG_ConvertPtr($input, (void **) &$1, SWIGTYPE_p_librdf_node_s, 0) < 0) {
     /* Allow NULL from php for librdf_node* */
-    if ((*$input)->type==IS_NULL)
+    if ($input->type==IS_NULL)
       $1=NULL;
    else
       SWIG_PHP_Error(E_ERROR, "Type error in argument $argnum of $symname. Expected $1_descriptor");


### PR DESCRIPTION
# Changed log
- This patch is from [here](http://bugs.librdf.org/mantis/view.php?id=622).
- This patch can support the php-binding on `php-7.+` versions.